### PR TITLE
Fix Responsiveness Problem

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,7 @@ const Container = styled.div`
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   background-size: 110% 110%;
   background: ${({ theme }) =>
     `linear-gradient(45deg, ${theme.colors.primary} 0%, ${theme.colors.black} 50%, ${theme.colors.primary} 100%)`};
@@ -96,11 +96,8 @@ const Container = styled.div`
   color: ${(props) => props.theme.colors.white};
   transition: all 0.2s ease-in-out;
 
-  ${({ theme }) => theme.breakpoints.down("sm")} {
-    padding-top: 20px;
-    padding-bottom: 50px;
-    height: 120vh;
-  }
+  padding-top: 20px;
+  padding-bottom: 50px;
 `;
 
 const Title = styled.span`
@@ -185,7 +182,7 @@ const TitleSubtitleContainer = styled.div`
 `;
 
 const SocialsBar = styled.div`
-  position: absolute;
+  position: fixed;
   bottom: 10px;
   right: 30px;
   display: flex;
@@ -193,6 +190,7 @@ const SocialsBar = styled.div`
   align-items: center;
   justify-content: flex-start;
   gap: 10px;
+  z-index: 10;
   span {
     font-family: ${({ theme }) => theme.fonts.thin};
   }

--- a/src/containers/Iphone/index.tsx
+++ b/src/containers/Iphone/index.tsx
@@ -136,9 +136,8 @@ export default function Iphone({
 const IphoneFrameContainer = styled.div`
   position: relative;
   width: 100%;
-  height: 100%;
-  max-width: 420px;
-  max-height: 780px;
+  width: 420px;
+  height: 780px;
   overflow: hidden;
   z-index: 1;
   display: flex;


### PR DESCRIPTION
This PR closes #1.

## TL;DR

Com as mudanças, o bug apresentado em #1 não irá mais acontecer, já que os componentes não limitarão a altura do viewport e o frame poderá ter dimensões livres. Além disso, permitindo o scoll vertical em telas menores permite que usuários possam ver todos os conteúdos do mockup de iPhone, para além do preview do icon.

## Mudanças
- É substituido o `height` do container mais exterior por um `height`, assim, não limitando o tamanho do frame dependendo da viewport.
- É removido o breakpoint que limitava a tela em resoluções pequenas, fazendo com que o frame se limitasse na tela.
- A posição dos links sociais do criador é trocada para `fixed`, assim, continuará em destaque independente do nível de scroll.